### PR TITLE
Update draft-ietf-iasa2-rfc4071bis.md

### DIFF
--- a/draft-ietf-iasa2-rfc4071bis.md
+++ b/draft-ietf-iasa2-rfc4071bis.md
@@ -32,7 +32,6 @@ author:
     email: jason_livingood@comcast.com
 
 informative:
-  RFC7691:
   RFC7437:
   RFC8318:
   RFC2026:
@@ -41,7 +40,6 @@ informative:
   RFC2031:
   RFC3710:
   RFC3233:
-  RFC4333:
 
   IETF-LLC-A:
     title: Limited Liability Company Agreement of IETF Administration LLC
@@ -140,7 +138,7 @@ administrative needs of the IETF and to ensure that the IETF LLC meets the
 needs of the IETF community.
 
 Eliminating the IAOC meant that changes were required in how
-trustees could be appointed ro the IETF Trust. The details of how this
+trustees could be appointed to the IETF Trust. The details of how this
 is done are outside the scope of this document but are covered in
 {{?I-D.ietf-iasa2-trust-update}}.
 
@@ -503,7 +501,7 @@ The IETF LLC Board itself is expected to take an active role in recruiting poten
 
 ## IETF LLC Board Director Term Length {#term-length}
 
-The term length for a Director is three years in length. The exceptions to this guideline will be for the terms for some Directors during the first full formation of the IETF LLC Board in order to establish staggered terms and for any appointments to fill a vacancy. The final exception is if a Director role is occupied by the IETF Chair ex officio, since that person’s term length is governed instead by the term lengths established in {{RFC7437}} (BCP10), Section 3.4.
+The term length for a Director is three years. The exceptions to this guideline will be for the terms for some Directors during the first full formation of the IETF LLC Board in order to establish staggered terms and for any appointments to fill a vacancy. The final exception is if a Director role is occupied by the IETF Chair ex officio, since that person’s term length is governed instead by the term lengths established in {{RFC7437}} (BCP10), Section 3.4.
 
 ## IETF LLC Board Director Limit {#term-limit}
 
@@ -511,7 +509,7 @@ A director may serve no more than two consecutive terms, with at least one full 
 
 An exception to the two consecutive term rule is for an IETF LLC-appointed Director. For such a Director, they may serve only one term via this appointment method, after which any subsequent terms would be occur via other appointment or selection processes (such as via the NomCom process).
 
-Lastly, partial terms of less than three years for the initial appointments to the first full board, for which some Directors will have terms of one or two years, do not count against the term limit.
+Lastly, partial terms of less than three years for the initial appointments to the First Full Board {{first-full-board}}, for which some Directors will have terms of one or two years, do not count against the term limit.
 
 The limit on consecutive terms supports the healthy regular introduction of new ideas and energy into the Board and mitigates potential long-term risk of ossification or conflict, without adversely impacting the potential pool of director candidates over time.
 
@@ -555,7 +553,7 @@ Following the formation of the first full IETF LLC Board, and at each subsequent
 
 # IETF LLC Funding
 
-The IETF LLC must function within a budget of costs balanced against limited revenues.  The IETF community expects the IETF LLC to work to attain that goal, in order to maintain a viable IETF support function that prodvides the environment within which the IETF's technical work can remain vibrant and productive. 
+The IETF LLC must function within a budget of costs balanced against limited revenues.  The IETF community expects the IETF LLC to work to attain that goal, in order to maintain a viable IETF support function that provides the environment within which the IETF's technical work can remain vibrant and productive. 
 
 The IETF LLC generates income from a few key sources at the time that this document was written, as enumerated below. Additional sources of income may be developed in the future, within the general bounds noted in {{fundraising-practices}}, and some of these may decline in relevance or go away. As a result this list is subject to change over time and is merely an example of the primary sources of income for the IETF LLC at the time of this writing:
 
@@ -631,21 +629,21 @@ the growth of the operating reserve.
 
 ## Annual Budget Process
 
-As noted in {{llc-responsibilities}}, the IETF LLC is responsible for managing the IETF's finances and budget. 
+As noted in {{#llc-responsibilities}}, the IETF LLC is responsible for managing the IETF's finances and budget. 
 A key part of this responsibility is establishing, maintaining, and successfully meeting an annual budget. This 
 is essential to the continued operation and vibrancy of the IETF's technical activities and establishes trust 
 with ISOC and donors that funds are being appropriately spent, and that financial oversight is being conducted 
 properly. This is also essential to the IETF LLC meeting applicable legal and tax requirements and is a core part of 
 the IETF LLC Board's fiduciary responsibilities. 
 
-As explained in {{staff-responsibilities}}, the IETF Executive Director is expected to develop, execute, and report on the 
+As explained in {{#staff-responsibilities}}, the IETF Executive Director is expected to develop, execute, and report on the 
 annual budget. Regular reporting is expected to include monthly and quarterly forecast vs. budget statements, including updated projections of income and expenses for the full fiscal year. 
 
-The IETF LLC Board, as explained in {{board-responsibilities}}, is expected to review and approve the 
+The IETF LLC Board, as explained in {{#board-responsibilities}}, is expected to review and approve the 
 budget, as well as to provide ongoing oversight of the budget and of any other significant financial matters. 
 
 The annual budget is expected to be developed in an open, transparent, and collaborative manner, in accordance with 
-{{principles}}. The specific timeline for the development, review, and approval of the IETF LLC annual budget is established by the IETF LLC Board and may be revised as needed. 
+{{#principles}}. The specific timeline for the development, review, and approval of the IETF LLC annual budget is established by the IETF LLC Board and may be revised as needed. 
 
 # IETF LLC Policies {#llc-policies}
 


### PR DESCRIPTION
Just nits.

Nit at the end of intro "appointed ro the IETF Trust".

Nit in "IETF LLC Board Director Term Length" drop "in length" from the first sentence, redundant.

Nit "prodvides" in "IETF LLC Funding."