### PR TITLE
minor term length tweak

### DIFF
--- a/draft-ietf-iasa2-rfc4071bis.md
+++ b/draft-ietf-iasa2-rfc4071bis.md
@@ -512,8 +512,8 @@ guideline are:
 
 * The Director slot occupied by the IETF Chair ex officio or a
   delegate selected by the IESG will serve a two-year term. This
-  allows the term length for this slot to align with the term lengths
-  established in {{RFC7437}} (BCP10), Section 3.4.
+  potentially allows the term length for this slot to align with the term lengths
+  established in {{RFC7437}} (BCP10), Section 3.4, should the IESG want to do so.
 
 ## IETF LLC Board Director Limit {#term-limit}
 


### PR DESCRIPTION
In case Alissa responds favorably - otherwise kill the PR.

> * The Director slot occupied by the IETF Chair ex officio or a delegate selected by the IESG will serve a two-year term. This allows the term length for this slot to align with the term lengths established in {{RFC7437}} (BCP10), Section 3.4.”

[JL] Is the 2nd sentence still okay? Will it always be aligned? Maybe we can soften it to something like: This potentially allows the term length for this slot to align with the term lengths established in {{RFC7437}} (BCP10), Section 3.4, should the IESG want to do so.