### PR TITLE
Lear change 2

### DIFF
--- a/draft-ietf-iasa2-rfc4071bis.md
+++ b/draft-ietf-iasa2-rfc4071bis.md
@@ -343,7 +343,8 @@ and should include a description of the decision or action to be
 reviewed, an explanation of how, in the requestor's opinion, the
 decision or action violates the BCPs or operational guidelines, and a
 suggestion for how the situation could be rectified.  All requests for
-review shall be posted publicly, and the IETF LLC Board is expected to
+review shall be sent to the IETF LLC, such as via email to llc@ietf.org. 
+The IETF LLC shall in turn publish those publicly, and is expected to
 respond publicly to these requests within a reasonable period,
 typically within 90 days.  It is up to the IETF LLC Board to determine
 what type of review and response is required, based on the nature of


### PR DESCRIPTION
As to this:

   All requests
   for review shall be posted publicly, 

This is necessary but not sufficient.  You need to be clear as to what this means, lest it be claimed that they did so and you didn’t follow process.  My suggestion is to replace it with something like:
   All requests
   for review shall be emailed to llc@ietf.org who SHALL in turn publish them.


Actual change was:
ll requests for
review shall be sent to the IETF LLC, such as via email to llc@ietf.org. 
The IETF LLC shall in turn publish those publicly, and is expected to
respond publicly to these requests within a reasonable period,
typically within 90 days.