### PR TITLE
Updated IASA term per Bob Hinden

### DIFF
--- a/draft-ietf-iasa2-rfc4071bis.md
+++ b/draft-ietf-iasa2-rfc4071bis.md
@@ -194,8 +194,8 @@ by the IETF LLC Board. (The IETF Trust function of the former IAOC was
 not included in the new responsibilities of the IETF LLC Board (See
 {{?I-D.ietf-iasa2-trust-update}}).)
 
-IASA: The original IETF Administrative Support Activity, defined by
-{{RFC4071}} and obsoleted by this document and the ISOC/IETF LLC
+IASA: The IETF Administrative Support Activity, defined by
+{{RFC4071}} and updated by this document and the ISOC/IETF LLC
 Agreement ({{IETF-LLC-A}}).
 
 IASA 2.0: Version 2.0 of the IETF Administrative Support Activity,


### PR DESCRIPTION
>    IASA: The original IETF Administrative Support Activity, defined by
    >    [RFC4071] and obsoleted by this document and the ISOC/IETF LLC
    >    Agreement ([IETF-LLC-A]).
    
    
    I disagree.  IASA is the general term that applies to IASA 1.0 and IASA
    2.0.  Perhaps in the future IASA 3.0.