### PR TITLE
Brian's Changes

### DIFF
--- a/draft-ietf-iasa2-rfc4071bis.md
+++ b/draft-ietf-iasa2-rfc4071bis.md
@@ -4,7 +4,7 @@ title: Structure of the IETF Administrative Support Activity, Version 2.0
 abbrev: IASA2
 docname: draft-ietf-iasa2-rfc4071bis-latest
 category: bcp
-obsoletes: BCP101, RFC4071, RFC4333, RFC7691
+obsoletes: RFC4071, RFC4333, RFC7691
 
 ipr: trust200902
 area: General
@@ -102,7 +102,7 @@ and ISOC in the fiscal and administrative support of the IETF standards
 process.  It also defines the membership and selection rules for the IETF 
 LLC Board.
 
-This document obsoletes {{RFC4071}} (BCP101), {{RFC4333}}, and {{RFC7691}}.
+This document obsoletes {{RFC4071}}, {{RFC4333}}, and {{RFC7691}}.
 
 --- middle
 


### PR DESCRIPTION
Maybe I missed some discussion, but this:

This document obsoletes [RFC4071] (BCP101), [RFC4333], and [RFC7691].

is very unusual by including "(BCP101)".

BCP101 is currently a set of three RFCs: RFC4071, RFC4371, and RFC7691.
This draft obsoletes only two of those. So it cannot claim to obsolete
BCP101 as a whole.

As already noted, draft-ietf-iasa2-trust-update-02 claims to update
RFC4071 (which makes no sense since 4071bis obsoletes it) and RFC4371
(without obsoleting it).

The fix for this is fiddly but trivial:

1. 4071bis should not claim to obsolete BCP101.
2. trust-update should not claim to update RFC4071.
3. trust-update should include a short text extract from RFC4371**.
4. trust-update should obsolete RFC4371.
5. 4071bis will be designated as BCP101 when published.
6. trust-update will be designated as BCPxxx when published.

** See https://mailarchive.ietf.org/arch/msg/iasa20/uQZsZiarA8u1lVWyOCQr-L6Pvfo

Regards
   Brian Carpenter